### PR TITLE
DNMY: Backport bump of HiGHS_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HiGHS"
 uuid = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 HiGHS_jll = "8fd58aa0-07eb-5a78-9b36-339c94fd15ea"
@@ -8,7 +8,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-HiGHS_jll = "=0.3.2"
+HiGHS_jll = "=0.3.2, =0.3.3"
 MathOptInterface = "0.9.17"
 julia = "1.3"
 


### PR DESCRIPTION
Related to #65

Backports #66 because we've made breaking changes on `master`.