### PR TITLE
Relax tolerance of test_RelativeGap

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -282,7 +282,7 @@ end
 function test_RelativeGap()
     model = _knapsack_model(mip = true, solver = "choose")
     MOI.optimize!(model)
-    @test ≈(MOI.get(model, MOI.RelativeGap()), 0.0; atol = 1e-14)
+    @test 0 <= MOI.get(model, MOI.RelativeGap()) <= 1e-4
     return
 end
 


### PR DESCRIPTION
This failed a recent run of `solver-tests.yml` in MOI. It's a bit strict regardless, so let's loosen.