### PR TITLE
Fix copy_to with empty constraint rows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HiGHS"
 uuid = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 HiGHS_jll = "8fd58aa0-07eb-5a78-9b36-339c94fd15ea"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2490,7 +2490,7 @@ function _extract_row_data(
     ::Type{S},
 ) where {S}
     F = MOI.ScalarAffineFunction{Float64}
-    row = length(I) == 0 ? 1 : I[end] + 1
+    row = length(rowlower) + 1
     list = _constraints(src, MOI.ScalarAffineFunction{Float64}, S)
     numrows = length(list)
     _add_sizehint!(rowlower, numrows)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -449,7 +449,7 @@ function test_copy_to_bug_172()
     index_map = MOI.copy_to(h, model)
     y = index_map[x]
     @test MOI.get(h, MOI.ConstraintFunction(), index_map[c1]) ≈ 2.0 * y
-    @test MOI.get(h, MOI.ConstraintFunction(), index_map[c2]) ≈ g
+    @test MOI.get(h, MOI.ConstraintFunction(), index_map[c2]) ≈ zero(F)
     @test MOI.get(h, MOI.ConstraintFunction(), index_map[c3]) ≈ 1.0 * y
     @test MOI.get(h, MOI.ConstraintSet(), index_map[c1]) == MOI.GreaterThan(0.0)
     @test MOI.get(h, MOI.ConstraintSet(), index_map[c2]) == MOI.GreaterThan(0.0)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -437,6 +437,25 @@ function test_attribute_TimeLimitSec()
     return
 end
 
+function test_copy_to_bug_172()
+    model = MOI.Utilities.Model{Float64}()
+    x = MOI.add_variable(model)
+    F = MOI.ScalarAffineFunction{Float64}
+    c1 = MOI.add_constraint(model, 2.0 * x, MOI.GreaterThan(0.0))
+    c2 = MOI.add_constraint(model, zero(F), MOI.GreaterThan(0.0))
+    c3 = MOI.add_constraint(model, 1.0 * x, MOI.EqualTo(1.0))
+    h = HiGHS.Optimizer()
+    MOI.set(h, MOI.Silent(), true)
+    index_map = MOI.copy_to(h, model)
+    y = index_map[x]
+    @test MOI.get(h, MOI.ConstraintFunction(), index_map[c1]) ≈ 2.0 * y
+    @test MOI.get(h, MOI.ConstraintFunction(), index_map[c2]) ≈ g
+    @test MOI.get(h, MOI.ConstraintFunction(), index_map[c3]) ≈ 1.0 * y
+    MOI.optimize!(h)
+    @test MOI.get(h, MOI.TerminationStatus()) == MOI.OPTIMAL
+    return
+end
+
 end
 
 TestMOIHighs.runtests()

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -451,6 +451,9 @@ function test_copy_to_bug_172()
     @test MOI.get(h, MOI.ConstraintFunction(), index_map[c1]) ≈ 2.0 * y
     @test MOI.get(h, MOI.ConstraintFunction(), index_map[c2]) ≈ g
     @test MOI.get(h, MOI.ConstraintFunction(), index_map[c3]) ≈ 1.0 * y
+    @test MOI.get(h, MOI.ConstraintSet(), index_map[c1]) == MOI.GreaterThan(0.0)
+    @test MOI.get(h, MOI.ConstraintSet(), index_map[c2]) == MOI.GreaterThan(0.0)
+    @test MOI.get(h, MOI.ConstraintSet(), index_map[c3]) == MOI.EqualTo(1.0)
     MOI.optimize!(h)
     @test MOI.get(h, MOI.TerminationStatus()) == MOI.OPTIMAL
     return


### PR DESCRIPTION
Closes #172 

This took me a while to find because...GLPK has the exact same bug. So I originally figured that two solvers meant the problem was in MOI.