### PR TITLE
Fix deleting ZeroOne constraints after MOI.optimize

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2338,6 +2338,10 @@ function MOI.delete(
     info = _info(model, ci)
     info.type = _TYPE_CONTINUOUS
     Highs_changeColIntegrality(model, info.column, kHighsVarTypeContinuous)
+    # optimize! sets bounds to [0, 1] if not present, so if we delete the
+    # ZeroOne constraint after a call to optimize!, then we need to reset the
+    # bounds.
+    Highs_changeColBounds(model, info.column, info.lower, info.upper)
     delete!(model.binaries, info)
     return
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -459,6 +459,23 @@ function test_copy_to_bug_172()
     return
 end
 
+function test_relax_integrality_after_solve()
+    model = HiGHS.Optimizer()
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variable(model)
+    MOI.add_constraint(model, x, MOI.LessThan(2.0))
+    c = MOI.add_constraint(model, x, MOI.ZeroOne())
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    f = 1.0 * x
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    @test ≈(MOI.get(model, MOI.VariablePrimal(), x), 1.0; atol = 1e-6)
+    MOI.delete(model, c)
+    MOI.optimize!(model)
+    @test ≈(MOI.get(model, MOI.VariablePrimal(), x), 2.0; atol = 1e-6)
+    return
+end
+
 end
 
 TestMOIHighs.runtests()


### PR DESCRIPTION
https://github.com/jump-dev/MathOptInterface.jl/pull/2318 is exposing all the bugs.