### PR TITLE
Optimize the approach to clear quadratic objective

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -936,19 +936,15 @@ function MOI.set(
     _check_ret(ret)
     model.is_objective_function_set = true
     if model.hessian !== nothing
-        index = HighsInt[row - 1 for col in 1:num_vars for row in col:num_vars]
-        start = HighsInt[0]
-        for col in 1:num_vars
-            push!(start, start[end] + num_vars - col + 1)
-        end
+        start = zeros(HighsInt, num_vars)
         ret = Highs_passHessian(
             model,
             num_vars,
-            length(index),
+            0,
             kHighsHessianFormatTriangular,
             start,
-            index,
-            fill(0.0, length(index)),
+            C_NULL,
+            C_NULL,
         )
         _check_ret(ret)
         model.hessian = nothing

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -713,6 +713,25 @@ function test_change_row_bounds_by_set_equal_to()
     return
 end
 
+function test_set_affine_after_quadratic()
+    model = HiGHS.Optimizer()
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variable(model)
+    MOI.add_constraint(model, x, MOI.GreaterThan(0.25))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    f = (x - 1.0)^2 + x + 1.0
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    @test ≈(MOI.get(model, MOI.VariablePrimal(), x), 0.5; atol = 1e-5)
+    @test ≈(MOI.get(model, MOI.ObjectiveValue()), 1.75; atol = 1e-5)
+    g = 2.0 * x + 3.0
+    MOI.set(model, MOI.ObjectiveFunction{typeof(g)}(), g)
+    MOI.optimize!(model)
+    @test ≈(MOI.get(model, MOI.VariablePrimal(), x), 0.25; atol = 1e-5)
+    @test ≈(MOI.get(model, MOI.ObjectiveValue()), 3.5; atol = 1e-5)
+    return
+end
+
 end
 
 TestMOIHighs.runtests()


### PR DESCRIPTION
It seems that we can pass `numnz=0` to empty the Hessian and clear quadratic objective.