### PR TITLE
Remove unneeded __init__ function

### DIFF
--- a/src/HiGHS.jl
+++ b/src/HiGHS.jl
@@ -24,7 +24,6 @@ end
 import PrecompileTools
 
 PrecompileTools.@setup_workload begin
-    __init__()
     PrecompileTools.@compile_workload begin
         let
             model = MOI.Utilities.CachingOptimizer(

--- a/src/HiGHS.jl
+++ b/src/HiGHS.jl
@@ -5,14 +5,9 @@
 
 module HiGHS
 
-import HiGHS_jll
+using HiGHS_jll: HiGHS_jll, libhighs
 import MathOptInterface as MOI
 import SparseArrays
-
-function __init__()
-    global libhighs = HiGHS_jll.libhighs
-    return
-end
 
 include("gen/libhighs.jl")
 include("MOI_wrapper.jl")

--- a/src/HiGHS.jl
+++ b/src/HiGHS.jl
@@ -5,7 +5,7 @@
 
 module HiGHS
 
-using HiGHS_jll: HiGHS_jll, libhighs
+import HiGHS_jll: libhighs
 import MathOptInterface as MOI
 import SparseArrays
 


### PR DESCRIPTION
I'm playing around with static compilation. This seemed easy enough to fix, to avoid:

```
Dynamic call to Base.convert(Type, String)
In C:\Users\visser_mn\.julia\packages\HiGHS\MQAyL\src\HiGHS.jl:13
```