### PR TITLE
Add pass names to solver functionality

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2980,6 +2980,78 @@ function _check_input_data(dest::Optimizer, src::MOI.ModelLike)
     return
 end
 
+function _pass_names_to_solver(optimizer; warn::Bool = true, max_name_length::Integer = 64)
+    _pass_variable_names_to_solver(optimizer; warn, max_name_length)
+    _pass_constraint_names_to_solver(optimizer; warn, max_name_length)
+    return
+end
+
+function _pass_variable_names_to_solver(optimizer; warn::Bool = true, max_name_length::Integer = 64)
+    n = length(optimizer.variable_info)
+    if n == 0
+        return
+    end
+    names = String["C$i" for i in 1:n]
+    duplicate_check = Set{String}()
+    for info in values(optimizer.variable_info)
+        if isempty(info.name)
+            continue
+        elseif length(info.name) > max_name_length
+            if warn
+                @warn(
+                    "Skipping variable name because it is longer than " *
+                    "$max_name_length characters: $(info.name)",
+                )
+            end
+        elseif info.name in duplicate_check
+            if warn
+                @warn("Skipping duplicate variable name $(info.name)")
+            end
+        else
+            names[info.column+1] = info.name
+            push!(duplicate_check, info.name)
+        end
+    end
+    for (col, name) in enumerate(names)
+        HiGHS.Highs_passColName(optimizer.inner, col - 1, name)
+    end
+    return
+end
+
+function _pass_constraint_names_to_solver(optimizer; warn::Bool = true, max_name_length::Integer = 64)
+    max_name_length = 64
+    n = length(optimizer.affine_constraint_info)
+    if n == 0
+        return
+    end
+    names = String["R$i" for i in 1:n]
+    duplicate_check = Set{String}()
+    for info in values(optimizer.affine_constraint_info)
+        if isempty(info.name)
+            continue
+        elseif length(info.name) > max_name_length
+            if warn
+                @warn(
+                    "Skipping constraint name because it is longer than " *
+                    "$max_name_length characters: $(info.name)",
+                )
+            end
+        elseif info.name in duplicate_check
+            if warn
+                @warn("Skipping duplicate constraint name $(info.name)")
+            end
+        else
+            names[info.row+1] = info.name
+            push!(duplicate_check, info.name)
+        end
+    end
+    for (row, name) in enumerate(names)
+        HiGHS.Highs_passRowName(optimizer.inner, row - 1, name)
+    end
+    return
+end
+
+
 MOI.supports_incremental_interface(::Optimizer) = true
 
 function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)


### PR DESCRIPTION
My main motivation for opening this PR is that building the model passing the names is note performant and most of the time I wish to avoid passing them.

Unfortunately, it happens quite often that while building the model I happen to have infeasible models and wish to write the lp to do further investigations. In my case, oftentimes, I want to write the lp with the HiGHS native lp writer.

A common pattern is to do something like this after realizing that the model is infeasible.

```julia

status = JuMP.termination_status(model)
if status == MOI.INFEASIBLE
    optimizer = JuMP.backend(model).optimizer.model.optimizer
    _pass_names_to_solver(optimizer)
    HiGHS.Highs_writeModel(optimizer.inner, lp_filename)
end
```

Since I happen to write this quite often I was wondering if we could integrate in the wrapper.