### PR TITLE
Pass names to the solver in HiGHS.Optimizer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-HiGHS_jll = "=1.5.1, =1.5.3, =1.6.0, =1.7.0, =1.7.1, =1.7.2, =1.8.0, =1.8.1, =1.9.0, =1.10.0"
+HiGHS_jll = "=1.7.1, =1.7.2, =1.8.0, =1.8.1, =1.9.0, =1.10.0"
 MathOptInterface = "1.34"
 PrecompileTools = "1"
 SparseArrays = "1.6"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -949,6 +949,10 @@ function MOI.set(
     info = _info(model, v)
     info.name = name
     model.name_to_variable = nothing
+    if !isempty(name)
+        ret = Highs_passColName(model, info.column, name)
+        _check_ret(ret)
+    end
     return
 end
 
@@ -1932,6 +1936,10 @@ function MOI.set(
     info = _info(model, c)
     info.name = name
     model.name_to_constraint_index = nothing
+    if !isempty(name)
+        ret = Highs_passRowName(model, info.row, name)
+        _check_ret(ret)
+    end
     return
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -947,12 +947,18 @@ function MOI.set(
     name::String,
 )
     info = _info(model, v)
+    if info.name == name
+        return  # The name is unchanged
+    end
     info.name = name
     model.name_to_variable = nothing
-    if !isempty(name)
-        ret = Highs_passColName(model, info.column, name)
-        _check_ret(ret)
+    if isempty(name)
+        # HiGHS does not support passing "" or C_NULL for names. So we default
+        # to a fairly standard C$i for the column name.
+        name = string("C", info.column)
     end
+    ret = Highs_passColName(model, info.column, name)
+    _check_ret(ret)
     return
 end
 
@@ -1934,12 +1940,18 @@ function MOI.set(
     name::String,
 )
     info = _info(model, c)
+    if info.name == name
+        return  # The name is unchanged
+    end
     info.name = name
     model.name_to_constraint_index = nothing
-    if !isempty(name)
-        ret = Highs_passRowName(model, info.row, name)
-        _check_ret(ret)
+    if isempty(name)
+        # HiGHS does not support passing "" or C_NULL for names. So we default
+        # to a fairly standard R$i for the crowolumn name.
+        name = string("R", info.row)
     end
+    ret = Highs_passRowName(model, info.row, name)
+    _check_ret(ret)
     return
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1140,7 +1140,7 @@ function test_VariableName()
     MOI.set(model, MOI.VariableName(), x, "x")
     MOI.get(model, MOI.VariableName(), x) == "x"
     GC.@preserve name begin
-        Highs_getColName(model, 0, name)
+        HiGHS.Highs_getColName(model, 0, name)
         @test unsafe_string(pointer(name)) == "x"
     end
     for _ in 1:2
@@ -1148,7 +1148,7 @@ function test_VariableName()
         MOI.set(model, MOI.VariableName(), x, "")
         MOI.get(model, MOI.VariableName(), x) == ""
         GC.@preserve name begin
-            Highs_getColName(model, 0, name)
+            HiGHS.Highs_getColName(model, 0, name)
             @test unsafe_string(pointer(name)) == "C0"
         end
     end
@@ -1163,7 +1163,7 @@ function test_ConstraintName()
     MOI.set(model, MOI.ConstraintName(), c, "c")
     MOI.get(model, MOI.ConstraintName(), c) == "c"
     GC.@preserve name begin
-        Highs_getRowName(model, 0, name)
+        HiGHS.Highs_getRowName(model, 0, name)
         @test unsafe_string(pointer(name)) == "c"
     end
     for _ in 1:2
@@ -1171,7 +1171,7 @@ function test_ConstraintName()
         MOI.set(model, MOI.ConstraintName(), c, "")
         MOI.get(model, MOI.ConstraintName(), c) == ""
         GC.@preserve name begin
-            Highs_getRowName(model, 0, name)
+            HiGHS.Highs_getRowName(model, 0, name)
             @test unsafe_string(pointer(name)) == "R0"
         end
     end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1133,6 +1133,51 @@ function test_ComputeInfeasibilityCertificate_primal_ray()
     return
 end
 
+function test_VariableName()
+    name = zeros(Cchar, kHighsMaximumStringLength)
+    model = HiGHS.Optimizer()
+    x = MOI.add_variable(model)
+    MOI.set(model, MOI.VariableName(), x, "x")
+    MOI.get(model, MOI.VariableName(), x) == "x"
+    GC.@preserve name begin
+        Highs_getColName(model, 0, name)
+        @test unsafe_string(pointer(name)) == "x"
+    end
+    for _ in 1:2
+        # Test setting the name twice
+        MOI.set(model, MOI.VariableName(), x, "")
+        MOI.get(model, MOI.VariableName(), x) == ""
+        GC.@preserve name begin
+            Highs_getColName(model, 0, name)
+            @test unsafe_string(pointer(name)) == "C0"
+        end
+    end
+    return
+end
+
+function test_ConstraintName()
+    name = zeros(Cchar, kHighsMaximumStringLength)
+    model = HiGHS.Optimizer()
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(model, 1.0 * x, MOI.EqualTo(2.0))
+    MOI.set(model, MOI.ConstraintName(), c, "c")
+    MOI.get(model, MOI.ConstraintName(), c) == "c"
+    GC.@preserve name begin
+        Highs_getRowName(model, 0, name)
+        @test unsafe_string(pointer(name)) == "c"
+    end
+    for _ in 1:2
+        # Test setting the name twice
+        MOI.set(model, MOI.ConstraintName(), c, "")
+        MOI.get(model, MOI.ConstraintName(), c) == ""
+        GC.@preserve name begin
+            Highs_getRowName(model, 0, name)
+            @test unsafe_string(pointer(name)) == "R0"
+        end
+    end
+    return
+end
+
 end  # module
 
 TestMOIHighs.runtests()

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1134,7 +1134,7 @@ function test_ComputeInfeasibilityCertificate_primal_ray()
 end
 
 function test_VariableName()
-    name = zeros(Cchar, kHighsMaximumStringLength)
+    name = zeros(Cchar, HiGHS.kHighsMaximumStringLength)
     model = HiGHS.Optimizer()
     x = MOI.add_variable(model)
     MOI.set(model, MOI.VariableName(), x, "x")
@@ -1156,7 +1156,7 @@ function test_VariableName()
 end
 
 function test_ConstraintName()
-    name = zeros(Cchar, kHighsMaximumStringLength)
+    name = zeros(Cchar, HiGHS.kHighsMaximumStringLength)
     model = HiGHS.Optimizer()
     x = MOI.add_variable(model)
     c = MOI.add_constraint(model, 1.0 * x, MOI.EqualTo(2.0))


### PR DESCRIPTION
Alternative to https://github.com/jump-dev/HiGHS.jl/pull/272

I think earlier versions of HiGHS either didn't support names, or they were quite slow. It looks like this was fixed in v1.7.1: https://github.com/ERGO-Code/HiGHS/pull/1782