### PR TITLE
Fix gen/libhighs.jl to point to the latest commit

### DIFF
--- a/src/gen/libhighs.jl
+++ b/src/gen/libhighs.jl
@@ -2626,11 +2626,11 @@ const HighsUInt = Cuint
 
 const CMAKE_BUILD_TYPE = "Release"
 
-const HIGHS_GITHASH = "6eca8325a4"
+const HIGHS_GITHASH = "364c83a51e"
 
 const HIGHS_VERSION_MAJOR = 1
 
-const HIGHS_VERSION_MINOR = 10
+const HIGHS_VERSION_MINOR = 11
 
 const HIGHS_VERSION_PATCH = 0
 


### PR DESCRIPTION
I should have noticed that https://github.com/jump-dev/HiGHS.jl/pull/281 didn't rebuild the correct commit.

x-ref https://github.com/JuliaPackaging/Yggdrasil/pull/11370#issuecomment-2953183337, https://github.com/JuliaPackaging/Yggdrasil/pull/11378