### PR TITLE
[WIP] Add conflict solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,8 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
+MathOptConflictSolver = "8c4f8055-bd93-4160-a86b-a0c04941dbff"
+
 [compat]
 HiGHS_jll = "=1.11.0"
 MathOptInterface = "1.34"
@@ -21,3 +23,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
+
+[sources]
+MathOptConflictSolver = {url = "https://github.com/jump-dev/MathOptConflictSolver.jl", rev = "jg/api"}

--- a/src/HiGHS.jl
+++ b/src/HiGHS.jl
@@ -7,6 +7,7 @@ module HiGHS
 
 import HiGHS_jll: libhighs
 import MathOptInterface as MOI
+import MathOptConflictSolver as MOCS
 import SparseArrays
 
 include("gen/libhighs.jl")

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -299,6 +299,8 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
 
     compute_infeasibility_certificates::Bool
 
+    conflict_solver::Union{Nothing, MOCS.Optimizer}
+
     function Optimizer()
         model = new(
             C_NULL,
@@ -317,6 +319,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
             _Solution(),
             nothing,
             true,
+            nothing,
         )
         MOI.empty!(model)
         if Sys.iswindows()
@@ -382,6 +385,7 @@ function MOI.empty!(model::Optimizer)
     ret = Highs_changeObjectiveOffset(model, 0.0)
     _check_ret(ret)
     model.callback_data = nothing
+    model.conflict_solver = nothing
     return
 end
 
@@ -402,7 +406,8 @@ function MOI.is_empty(model::Optimizer)
            model.name_to_constraint_index === nothing &&
            isempty(model.solution) &&
            iszero(offset[]) &&
-           model.callback_data === nothing
+           model.callback_data === nothing &&
+           model.conflict_solver === nothing
 end
 
 MOI.get(model::Optimizer, ::MOI.RawSolver) = model
@@ -2186,6 +2191,7 @@ function _set_variable_primal_start(model::Optimizer)
 end
 
 function MOI.optimize!(model::Optimizer)
+    model.conflict_solver = nothing
     for info in model.binaries
         Highs_changeColBounds(
             model,
@@ -3314,3 +3320,27 @@ end
 @enum(HighsObjSense, kMinimize = 1, kMaximize = -1)
 @enum(HighsVartype, kContinuous = 0, kInteger = 1, kImplicitInteger = 2)
 @enum(HighsStatus, HighsStatuskError = -1, HighsStatuskOk, HighsStatuskWarning)
+
+function MOI.compute_conflict!(model::Optimizer)
+    solver = MOCS.Optimizer()
+    MOI.set(solver, MOCS.InfeasibleModel(), model)
+    MOI.set(solver, MOCS.InnerOptimizer(), Optimizer)
+    MOI.compute_conflict!(solver)
+    model.conflict_solver = solver
+    return
+end
+
+function MOI.get(optimizer::Optimizer, attr::MOI.ConflictStatus)
+    if optimizer.conflict_solver === nothing
+        return MOI.COMPUTE_CONFLICT_NOT_CALLED
+    end
+    return MOI.get(optimizer.conflict_solver, attr)
+end
+
+function MOI.get(
+    optimizer::Optimizer,
+    attr::MOI.ConstraintConflictStatus,
+    con::MOI.ConstraintIndex,
+)
+    return MOI.get(optimizer.conflict_solver, attr, con)
+end


### PR DESCRIPTION
Here is the simplest example:
```julia
using HiGHS, JuMP
model = Model(HiGHS.Optimizer)
set_silent(model)
@variable(model, 0 <= x <= 10)
@variable(model, 0 <= y <= 20)
@constraint(model, c1, 0 <= x + y <= 1)
@constraint(model, c2, x + y >= 2)
@objective(model, Max, x + y)
optimize!(model)
@show termination_status(model)
compute_conflict!(model)
@show get_attribute(model, MOI.ConflictStatus())
iis_model, _ = copy_conflict(model);
print(iis_model)
```

- [ ] register MathOptConflictSolver (after choosing a name)
- [ ] change to a proper dependency
- [ ] add tests