### PR TITLE
Fix Highs_setSparseSolution when start outside bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HiGHS"
 uuid = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
-version = "1.19.1"
+version = "1.19.2"
 
 [deps]
 HiGHS_jll = "8fd58aa0-07eb-5a78-9b36-339c94fd15ea"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2180,9 +2180,11 @@ end
 function _set_variable_primal_start(model::Optimizer)
     index, value = Cint[], Cdouble[]
     for (x, info) in model.variable_info
-        if info.start !== nothing
+        if info.start !== nothing && info.lower <= info.upper
             push!(index, info.column)
-            push!(value, info.start)
+            # HiGHS will error if we attempt to set a start value outside the
+            # variable bounds.
+            push!(value, clamp(info.start, info.lower, info.upper))
         end
     end
     if !isempty(index)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1213,6 +1213,24 @@ function test_issue_287()
     return
 end
 
+function test_primal_start_outside_bounds()
+    model = HiGHS.Optimizer()
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variable(model)
+    MOI.add_constraint(model, x, MOI.GreaterThan(0.0))
+    MOI.set(model, MOI.VariablePrimalStart(), x, -1.0)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+    c = MOI.add_constraint(model, x, MOI.LessThan(1.0))
+    MOI.set(model, MOI.VariablePrimalStart(), x, 2.0)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+    MOI.set(model, MOI.ConstraintSet(), c, MOI.LessThan(-1.0))
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
+    return
+end
+
 end  # module
 
 TestMOIHighs.runtests()


### PR DESCRIPTION
Follow-up to #300. Don't ask why someone might set an infeasible starting solution, but at least PowerModels was:

<img width="800" height="250" alt="image" src="https://github.com/user-attachments/assets/b8db4093-21d6-438c-8225-bcb938e86625" />
