### PR TITLE
Remove job argument from test runner

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,6 @@ import HiGHS
 import ParallelTestRunner
 import Test
 
-push!(ARGS, "--jobs=4")
-
 is_test_file(f) = startswith(f, "test_") && endswith(f, ".jl")
 
 testsuite = Dict{String,Expr}()


### PR DESCRIPTION
Removed the '--jobs=4' argument from ARGS.

This was since fixed in ParallelTestRunner