### PR TITLE
Remove GC during Highs_run

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2291,16 +2291,8 @@ function MOI.optimize!(model::Optimizer)
         ]
         MOI.set(model, CallbackFunction(cb_types), (args...) -> Cint(0))
     end
-    # if `Highs_run` implicitly uses memory or other resources owned by `model`, preserve it
-    GC.@preserve model begin
-        # allow Julia to GC while this thread is in `Highs_run`
-        gc_state = ccall(:jl_gc_safe_enter, Int8, ())
-        # We disable sigint here so that it can be called only when we are in a
-        # try-catch of our CallbackFunction.
-        ret = disable_sigint(() -> _Highs_run_workaround_issue_316(model))
-        # leave GC-safe region, waiting for GC to complete if it's running
-        ccall(:jl_gc_safe_leave, Cvoid, (Int8,), gc_state)
-    end
+    # try-catch of our CallbackFunction.
+    ret = disable_sigint(() -> _Highs_run_workaround_issue_316(model))
     if has_default_callback
         MOI.set(model, CallbackFunction(), nothing)
     end


### PR DESCRIPTION
It is not thread-safe to call `Highs_destory` during `Highs_run`: https://github.com/ERGO-Code/HiGHS/pull/3136#issuecomment-4909892785

This was originally added by https://github.com/jump-dev/HiGHS.jl/pull/178. The original motivation isn't needed anymore, because we have a default callback the re-enters Julia to handle interrupts etc.

This might still not fix the thread-safety issue; that might need some changes in HiGHS itself.

