### PR TITLE
Remove --parallel=false workaround in the tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,6 @@
 
 import HiGHS
 import ParallelTestRunner
-import Test
 
 is_test_file(f) = startswith(f, "test_") && endswith(f, ".jl")
 
@@ -16,10 +15,4 @@ for (root, dirs, files) in walkdir(@__DIR__)
     end
 end
 
-if "--parallel=false" in ARGS
-    Test.@testset "$file" for file in keys(testsuite)
-        include(file)
-    end
-else
-    ParallelTestRunner.runtests(HiGHS, ARGS; testsuite)
-end
+ParallelTestRunner.runtests(HiGHS, ARGS; testsuite)


### PR DESCRIPTION
This was originally needed because of a thread-safety bug in HiGHS