### PR TITLE
Re-enable kHighsCallbackSimplexInterrupt in default callback

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2301,9 +2301,7 @@ function MOI.optimize!(model::Optimizer)
         # https://github.com/JuliaLang/julia/issues/2622 --- set a null
         # callback.
         cb_types = [
-            # See Issue 291. The SimplexInterrupt callback in HiGHS@1.11 is very
-            # slow.
-            # kHighsCallbackSimplexInterrupt,
+            kHighsCallbackSimplexInterrupt,
             kHighsCallbackIpmInterrupt,
             kHighsCallbackMipInterrupt,
         ]


### PR DESCRIPTION
Closes #291

There's now no difference. It looks like this was fixed sometime between v1.14 and v1.15, which is a bit unfortunate because I don't really want to bisect to find the cause.

```Julia
(HiGHS) pkg> st
Project HiGHS v1.25.1
Status `~/git/jump-dev/HiGHS/Project.toml`
  [8c4f8055] MathOptIIS v0.2.0
  [b8f27783] MathOptInterface v1.53.0
  [aea7be01] PrecompileTools v1.3.4
  [8fd58aa0] HiGHS_jll v1.15.1+1
  [656ef2d0] OpenBLAS32_jll v0.3.34+0
  [37e2e46d] LinearAlgebra v1.12.0
  [2f01184e] SparseArrays v1.12.0

julia> import HiGHS_jll: libhighs

julia> cb(::Cint, ::Ptr{Cchar}, ::Ptr{Cvoid}, ::Ptr{Cvoid}, ::Ptr{Cvoid}) = nothing
cb (generic function with 1 method)

julia> function main(run_callback::Bool)
           highs = @ccall libhighs.Highs_create()::Ptr{Cvoid}
           @ccall libhighs.Highs_readModel(highs::Ptr{Cvoid}, "debug_model.mps"::Ptr{Cchar})::Cint
           @ccall libhighs.Highs_setDoubleOptionValue(highs::Ptr{Cvoid}, "time_limit"::Ptr{Cchar}, 20.0::Cdouble)::Cint
           callback_cfn = @cfunction(
               cb, Cvoid, (Cint, Ptr{Cchar}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
           )
           @ccall libhighs.Highs_setCallback(highs::Ptr{Cvoid}, callback_cfn::Ptr{Cvoid}, C_NULL::Ptr{Cvoid})::Cint
           if run_callback
               @ccall libhighs.Highs_startCallback(highs::Ptr{Cvoid}, 1::Cint)::Cint
           end
           @ccall libhighs.Highs_run(highs::Ptr{Cvoid})::Cint
           @ccall libhighs.Highs_destroy(highs::Ptr{Cvoid})::Cvoid
           return
       end
main (generic function with 1 method)

julia> main(true)
Running HiGHS 1.15.1 (git hash: 04024d701f): Copyright (c) 2026 under MIT licence terms
Includes third-party software components, see THIRD_PARTY_NOTICES.md for full details
Using BLAS: Apple Accelerate 
Number of PL entries in BOUNDS section is 1738
LP debug_model has 991849 rows; 1097468 cols; 3829286 nonzeros
Coefficient ranges:
  Matrix  [1e-05, 5e+03]
  Cost    [1e-02, 3e+06]
  Bound   [1e-04, 2e+07]
  RHS     [3e-02, 9e+06]
WARNING: Problem has some excessively large costs
WARNING: Problem has some excessively small column bounds
WARNING: Problem has some excessively large column bounds
WARNING: Problem has some excessively large row bounds
WARNING:    Consider scaling the objective by 1e-1, or setting the user_objective_scale option to -2
WARNING:    Consider scaling the    bounds by 1e-2, or setting the user_bound_scale option to -5
Presolving model
876081 rows, 961643 cols, 3426955 nonzeros 0s
543429 rows, 898071 cols, 2722903 nonzeros 1s
Dependent equations search running on 49957 equations with time limit of 1.00s
Dependent equations search terminated after 0.00734s due to expected time exceeding limit
543240 rows, 897818 cols, 2701198 nonzeros 1s
Presolve reductions: rows 543240(-448609); columns 897818(-199650); nonzeros 2701198(-1128088) 
Solving the presolved LP
Using dual simplex solver
  Iteration        Objective     Infeasibilities num(sum)
          0    -3.1200325303e+02 Ph1: 33076(4.31857e+08); Du: 162(312.003) 1.9s
     145256     4.1248652698e+11 Pr: 95886(4.04086e+09); Du: 0(1.2893e-05) 7.1s
     266211     4.1832688218e+11 Pr: 77863(5.30585e+10); Du: 0(1.44554e-05) 12.2s
     324958     4.1839976435e+11 Pr: 64484(8.65832e+09); Du: 0(1.35885e-05) 17.6s
     352265     4.1844020281e+11 20.0s
Model name          : debug_model
Model status        : Time limit reached
Simplex   iterations: 352265
Objective value     :  4.1816517881e+11
HiGHS run time      :         20.03

julia> main(false)
Running HiGHS 1.15.1 (git hash: 04024d701f): Copyright (c) 2026 under MIT licence terms
Includes third-party software components, see THIRD_PARTY_NOTICES.md for full details
Using BLAS: Apple Accelerate 
Number of PL entries in BOUNDS section is 1738
LP debug_model has 991849 rows; 1097468 cols; 3829286 nonzeros
Coefficient ranges:
  Matrix  [1e-05, 5e+03]
  Cost    [1e-02, 3e+06]
  Bound   [1e-04, 2e+07]
  RHS     [3e-02, 9e+06]
WARNING: Problem has some excessively large costs
WARNING: Problem has some excessively small column bounds
WARNING: Problem has some excessively large column bounds
WARNING: Problem has some excessively large row bounds
WARNING:    Consider scaling the objective by 1e-1, or setting the user_objective_scale option to -2
WARNING:    Consider scaling the    bounds by 1e-2, or setting the user_bound_scale option to -5
Presolving model
876081 rows, 961643 cols, 3426955 nonzeros 0s
543429 rows, 898071 cols, 2722903 nonzeros 1s
Dependent equations search running on 49957 equations with time limit of 1.00s
Dependent equations search terminated after 0.00718s due to expected time exceeding limit
543240 rows, 897818 cols, 2701198 nonzeros 1s
Presolve reductions: rows 543240(-448609); columns 897818(-199650); nonzeros 2701198(-1128088) 
Solving the presolved LP
Using dual simplex solver
  Iteration        Objective     Infeasibilities num(sum)
          0    -3.1200325303e+02 Ph1: 33076(4.31857e+08); Du: 162(312.003) 2.0s
     141301     4.1247382438e+11 Pr: 96347(5.17077e+09); Du: 0(1.27587e-05) 7.1s
     264129     4.1832446941e+11 Pr: 77385(4.42127e+10); Du: 0(1.44554e-05) 12.4s
     322595     4.1839866382e+11 Pr: 64917(9.96254e+09); Du: 0(1.34238e-05) 17.6s
     342518     4.1843088410e+11 20.0s
Model name          : debug_model
Model status        : Time limit reached
Simplex   iterations: 342518
Objective value     :  4.1815592903e+11
HiGHS run time      :         20.03
```